### PR TITLE
Hide several unused pages; change repositories

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -198,6 +198,9 @@ exclude:
   - package.json
   - package-lock.json
   - _pages/about_einstein.md
+  - _pages/cv.md
+  - _pages/dropdown.md
+  - _pages/teaching.md
   - purgecss.config.js
   - README.md
   - readme_preview/

--- a/_data/repositories.yml
+++ b/_data/repositories.yml
@@ -1,14 +1,12 @@
 github_users:
-  - torvalds
-  - alshedivat
+  - RavenKiller
+  - CrystalSixone
+  - Candyaner
+  - stone-ziyan
 
 repo_description_lines_max: 2
 
 github_repos:
-  - alshedivat/al-folio
-  - jekyll/jekyll
-  - twbs/bootstrap
-  - jquery/jquery
-  - FortAwesome/Font-Awesome
-  - mathjax/MathJax
-  - jpswalsh/academicons
+  - RavenKiller/MEE
+  - RavenKiller/IA-HWP
+  - RavenKiller/TAC


### PR DESCRIPTION
Hide `cv.md`, `dropdown.md` and `teaching.md`, as they are currently not used. 
Add github users and repositories into `_data/repositories.yml`.